### PR TITLE
Revert "feat(Vim): set background=light"

### DIFF
--- a/_colors-italics.vim
+++ b/_colors-italics.vim
@@ -8,8 +8,6 @@
 " https://neovim.io/doc/user/options.html#'termguicolors'
 set termguicolors
 
-set background=light
-
 if filereadable(expand('~/.vimrc_background'))
   " See:
   " https://github.com/chriskempson/base16-vim#256-colorspace


### PR DESCRIPTION
> Setting this option does not change the background color, it tells Vim what the background color looks like. For changing the background color, see :h :hi-normal.
> When 'background' is set Vim will adjust the default color groups for the new value. But the colors used for syntax highlighting will not change.

This reverts commit 5824916a6c1055855295ea4897118b4bd38d3df9.

Close #48