### PR TITLE
docs(zsh): add a comment to each example history line

### DIFF
--- a/zsh/.zsh_history.example
+++ b/zsh/.zsh_history.example
@@ -1,25 +1,25 @@
-: 1760301857:0;sudo vim /etc/hosts
-: 1760658971:0;pnpm upgrade --latest --interactive
-: 1761055513:0;brew upgrade font-iosevka-slab
-: 1761315658:0;direnv allow
-: 1761406911:0;npx npkill
-: 1761736490:0;docker compose stats
-: 1762054277:0;brew upgrade lazygit
-: 1762456224:0;e ~/.zshrc
-: 1762456278:0;source ~/.zshrc
-: 1763412907:0;brew upgrade starship
-: 1763556911:0;echo .git > .rgignore
+: 1760301857:0;sudo vim /etc/hosts # Edit the hosts file
+: 1760658971:0;pnpm upgrade --latest --interactive # Pick which dependencies to upgrade
+: 1761055513:0;brew upgrade font-iosevka-slab # Upgrade the terminal font
+: 1761315658:0;direnv allow # Authorize the .envrc in this directory
+: 1761406911:0;npx npkill # Find and delete node_modules folders
+: 1761736490:0;docker compose stats # Live resource usage of the containers
+: 1762054277:0;brew upgrade lazygit # Upgrade lazygit
+: 1762456224:0;e ~/.zshrc # Edit the zsh config
+: 1762456278:0;source ~/.zshrc # Reload the zsh config
+: 1763412907:0;brew upgrade starship # Upgrade the prompt
+: 1763556911:0;echo .git > .rgignore # Hide .git from ripgrep results
 : 1771791203:0;git rerere clear # Clear the Git rerere cache
-: 1771792334:0;brew upgrade claude-code
-: 1771792629:0;git remote prune origin
-: 1771855139:0;cp ~/dotfiles/example-configs/* .
-: 1771855166:0;cp ~/dotfiles/example-configs/.* .
-: 1771855469:0;pnpm add --save-dev --save-exact prettier
-: 1771855523:0;pnpm add --save-dev --save-exact prettier-plugin-organize-imports
+: 1771792334:0;brew upgrade claude-code # Upgrade Claude Code
+: 1771792629:0;git remote prune origin # Delete local refs to removed remote branches
+: 1771855139:0;cp ~/dotfiles/example-configs/* . # Copy example configs into a new project
+: 1771855166:0;cp ~/dotfiles/example-configs/.* . # Copy the hidden example configs too
+: 1771855469:0;pnpm add --save-dev --save-exact prettier # Install Prettier pinned to an exact version
+: 1771855523:0;pnpm add --save-dev --save-exact prettier-plugin-organize-imports # Sort imports with Prettier
 : 1777490809:0;brew outdated # Check for upgradable packages
 : 1777490825:0;brew upgrade # Upgrade all packages
 : 1777510634:0;lsof -iTCP:3000 -n -P # What process is using port 3000
 : 1777510800:0;defaults write com.apple.finder AppleShowAllFiles -boolean true && killall Finder # Show hidden files in Finder
-: 1779580601:0;k3d cluster list
+: 1779580601:0;k3d cluster list # List local k3d clusters
 : 1779977656:0;date +"%Y-%m-%d %H:%M" | pbcopy # Current date, no seconds
 : 1779977809:0;date +"%Y-%m-%d %H:%M:%S" | pbcopy # Current date WITH seconds


### PR DESCRIPTION
Annotate the remaining uncommented lines in .zsh_history.example in
the same trailing-comment style as the existing entries, so every
example explains what the command is for.

https://claude.ai/code/session_01Lvy96bX1BdLU2eYZTUGegS